### PR TITLE
Content provider improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,30 @@ This content is here for testing purposes, and will surely be deleted on the
 
 ### Directory
 
-Will just serve the files that are set in the directory path
+Serve the files that are set in the directory path. The Content-Type for each
+file will be set according to the file extension. 
+
+With the `attempt_extensions` option, we can provide a list of file extensions
+to attempt when we cannot match directly the path to a file in the filesystem.
+Useful for example if we want to have a path like `/foo/bar/` to return a 
+json file (because the content-type is infered from the file extension), if 
+we add the `.json` file, it will try to find the `/foo/bar.json` file. This
+also allows to have a `/foo/bar/` dir in the filesystem, and put inside files
+like `/foo/bar/1`, `/foo/bar/2`, and have those inside the directory.
+
+With the `dunder_querystrings` option (`true` / `false`), sorts the query params alphabetically, and
+joins them after the file name using "dunder" (double underscore) separators
+between key, value pairs. Key Value pairs are split by using a single
+underscore. So a path like: /foo/bar?a=foo&b=bar will become:
+/foo/bar__a_foo__b_bar.
 
 ```json
 {
     "source": "directory",
     "config": {
-        "dir": "./example/data"
+        "dir": "./example/data",
+        "attempt_extensions": [".json", "yaml"],
+        "dunder_querystrings": true
     }
 }
 ```

--- a/cmd/reqstatsrv/main.go
+++ b/cmd/reqstatsrv/main.go
@@ -18,6 +18,7 @@ func main() {
 
 	cfg := config.DefaultConfig()
 	if len(os.Args) > 1 {
+		fmt.Printf("loading from config file %s\n", os.Args[1])
 		fname := os.Args[1]
 		b, err := os.ReadFile(fname)
 		if err != nil {
@@ -30,6 +31,7 @@ func main() {
 			return
 		}
 	}
+	fmt.Printf("config:\n%#v\n", cfg)
 	launchServer(cfg)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,8 +27,8 @@ func DefaultConfig() *Config {
 					Behaviour{
 						Name: "slower",
 						Config: map[string]interface{}{
-							"freq": 0.5,
-							"seed": 1,
+							"max_bytes_per_second": 1024,
+							"flush_bytes":          1024,
 						},
 					},
 					Behaviour{
@@ -55,6 +55,11 @@ func DefaultConfig() *Config {
 					Source: "directory",
 					Config: map[string]interface{}{
 						"dir": "./example/data",
+						"attempt_extensions": []string{
+							"json",
+							"yaml",
+						},
+						"dunder_querystring": true,
 					},
 				},
 			},

--- a/content/directory.go
+++ b/content/directory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 
 	"github.com/dhontecillas/reqstatsrv/behaviour"
 	"github.com/dhontecillas/reqstatsrv/config"
@@ -14,9 +15,22 @@ func DirectoryContentHandler(cfg *config.Content, nestedBuilder NestedContentBui
 	return NewDirectoryContent(DirectoryContentConfigFromMap(cfg.Config))
 }
 
+// DirectoryContentConfig allows to define how to find the fake files
+// inside a directory.
+//
+// AttemptExtensions allows to define a set of extension to append, when
+// the path in the url does not match a file.
+//
+// DunderQueryStrings option, sorts the query params alphabetically, and
+// joins them after the file using "dunder" (double underscore) separators
+// between key, value pairs. Key Value pairs are split by using a single
+// underscore. So a path like: /foo/bar?a=foo&b=bar will become:
+// /foo/bar__a_foo__b_bar
 type DirectoryContentConfig struct {
-	Dir          string `json:"dir"`
-	EndpointPath string `json:"endpoint_path"`
+	Dir                string   `json:"dir"`
+	EndpointPath       string   `json:"endpoint_path"`
+	AttemptExtensions  []string `json:"attempt_extensions"`
+	DunderQueryStrings bool     `json:"dunder_querystrings"`
 }
 
 func DirectoryContentConfigFromMap(m map[string]interface{}) *DirectoryContentConfig {
@@ -34,31 +48,74 @@ func DirectoryContentConfigFromMap(m map[string]interface{}) *DirectoryContentCo
 }
 
 type DirectoryContent struct {
-	dir        http.Dir
-	parentPath string
+	dir                http.Dir
+	parentPath         string
+	attemptExtensions  []string
+	dunderQueryStrings bool
 }
 
 func NewDirectoryContent(cfg *DirectoryContentConfig) http.Handler {
 	// the problem with FileServer is that the status code from
 	// the context is not respected
 	return &DirectoryContent{
-		dir:        http.Dir(cfg.Dir),
-		parentPath: cfg.EndpointPath,
+		dir:                http.Dir(cfg.Dir),
+		parentPath:         cfg.EndpointPath,
+		attemptExtensions:  cfg.AttemptExtensions,
+		dunderQueryStrings: cfg.DunderQueryStrings,
 	}
 }
 
-func (c *DirectoryContent) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if f, err := c.dir.Open(req.URL.Path); err == nil {
-		if b, rerr := io.ReadAll(f); rerr == nil {
-			h := rw.Header()
-			h.Set("Content-Length", fmt.Sprintf("%d", len(b)))
-			if ct := getContentTypeFromExtension(req.URL.Path); ct != "" {
-				h.Set("Content-Type", ct)
-			}
-			rw.WriteHeader(behaviour.ResponseStatusOr(req, 200))
-			rw.Write(b)
-			return
+func (c *DirectoryContent) findFile(req *http.Request) (http.File, error) {
+	// we remove the final `/` if present, and remove '..' / '.' path elements
+	p := path.Clean(req.URL.Path)
+
+	// TODO: apply the Dunder config option to be able to serve different
+	// files based on the query strings
+
+	f, err := c.dir.Open(p)
+	if err == nil {
+		s, serr := f.Stat()
+		if serr == nil && !s.IsDir() {
+			return f, err
 		}
 	}
+
+	// attempt with any of the allowed extensions
+	for _, ext := range c.attemptExtensions {
+		if f, err = c.dir.Open(p + "." + ext); err == nil {
+			return f, err
+		}
+	}
+
+	return nil, fmt.Errorf("not found")
+}
+
+func (c *DirectoryContent) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	f, err := c.findFile(req)
+	if err != nil {
+		rw.WriteHeader(behaviour.ResponseStatusOr(req, 404))
+		return
+	}
+
+	b, rerr := io.ReadAll(f)
+	if rerr != nil {
+		rw.WriteHeader(behaviour.ResponseStatusOr(req, 503))
+		return
+	}
+
+	h := rw.Header()
+	h.Set("Content-Length", fmt.Sprintf("%d", len(b)))
+	// try to infer the content type of the file
+	var ct string
+	if s, err := f.Stat(); err != nil {
+		ct = getContentTypeFromExtension(s.Name())
+	} else {
+		ct = getContentTypeFromExtension(req.URL.Path)
+	}
+	if ct != "" {
+		h.Set("Content-Type", ct)
+	}
+
 	rw.WriteHeader(behaviour.ResponseStatusOr(req, 200))
+	rw.Write(b)
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,10 @@
+# TODO
+
+- Apply behaviours to alerady exisisting live APIs (proxy them
+    applying the behaviours), like:
+    - https://www.igdb.com/api
+    - https://fakestoreapi.com/
+    - https://www.edamam.com/
+    - https://favqs.com/api
+    - https://api.nasa.gov/
+    - https://docs.mapbox.com/api/overview/


### PR DESCRIPTION
Add options to `directory` content:

- add the `attempt_extenstion` list of extensions to try to add to the request path to load the content from.
- add the `dunder_querystrings` option, to compose the file name with the values from the query strings.
- add a list of **TODO**s to keep track of tasks