### PR TITLE
fix: directory content allow params in the route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,21 @@
-VERSION ?= "v0.3"
+VERSION ?= "v0.4"
 
 build:
 	go build -o reqstatsrv ./cmd/reqstatsrv
 .PHONY: build
 
 docker:
-	docker build -t dhontecillas/reqstatsrv:latest \
+	docker build \
+		-t dhontecillas/reqstatsrv:latest \
 		-t dhontecillas/reqstatsrv:${VERSION} . 
 .PHONY: docker
 
 
-dockerrun:
+dockerrun: docker
 	docker run --rm -p 9876:9876 \
 		-v ./example:/etc/reqstatsrv \
-		dhontecillas/reqstatsrv:${VERSION}  /reqstatsrv /etc/reqstatsrv/config/example.dockerized.json
+		dhontecillas/reqstatsrv:${VERSION} \
+		/reqstatsrv /etc/reqstatsrv/config/example.dockerized.json
 .PHONY: dockerrun
 
 test:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # ReqStatSrv
 
-A dummy server that reports the number of requests made.
+An http server to for **fake responses with weird
+behaviours**: delayed responses, connection cuts,
+slow responses...
 
 ## Usage:
 
 ```bash
-docker pull dhontecillas/reqstatsrv:v0.2
-docker run --rm -p 9876:9876 -v ./example:/etc/reqstatsrv dhontecillas/reqstatsrv:v0.2  /reqstatsrv /etc/config/example.json
+docker pull dhontecillas/reqstatsrv:v0.4
+docker run --rm -p 9876:9876 \
+    -v ./example:/etc/reqstatsrv \
+    dhontecillas/reqstatsrv:v0.4 \
+    /reqstatsrv /etc/config/example.json
 ```
 
 or from the base repo run:
@@ -15,14 +20,11 @@ or from the base repo run:
 make dockerrun
 ```
 
+## Example: 
+
 # Configuration
 
-The server uses the Go's standard lib router, so, for now it does not
-have variable path matching (`/foo/{something_to_match}/var`), or 
-matching by request method (`GET`, `POST`, etc..) for now (but a new 
-router implementation is expected to land soon in next version of Go).
-
-The server can be configured by passing a **JSON** config file as only
+The server is be configured using **JSON** config file as the only
 argument.
 
 At the root level, you can configure:
@@ -30,14 +32,17 @@ At the root level, you can configure:
 - `host`: the address to bind to 
 - `endpoints`: the list of endpoints to serve
 
-## Enpoint
+
+## Endpoint
 
 The endpoint has:
 
-- `method`: currently is not used to match the request, as we
-    are waiting for the new Go router to land in the stdlib.
-- `path_pattern`: a simple "path prefix" to match (no vars, nor
-    wildcards allowed for now). 
+- `method`: an uppercased http method: 'GET', 'POST', ...
+- `path_pattern`: The server uses the Go's standard lib router, so, 
+    to define a route you can follow the 
+    [patterns documentation](https://pkg.go.dev/net/http#hdr-Patterns-ServeMux),
+    with the slight difference that the method is specified in the
+    `method` field.
 - `behaviour`: configuration about how we want the response to
     behave (see explanation below).
 - `content`: configuration about the content to serve with the

--- a/behaviour/status_test.go
+++ b/behaviour/status_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/dhontecillas/reqstatsrv/config"
+	"github.com/dhontecillas/reqstatsrv/stats"
 )
 
 func TestBehaviourStatus_Happy(t *testing.T) {
@@ -53,14 +54,15 @@ func TestBehaviourStatus_Normalize(t *testing.T) {
 		return
 	}
 
-	v200 := s.CodeDistribution[0].Val
-	if v200 <= 0.33 || v200 >= 0.34 {
-		t.Errorf("expected 200 value 0.3333.. got %f", v200)
+	distr := stats.NewIntDistribution(s.CodeDistribution)
+	v200 := distr.Val(0.32)
+	if v200 != 200 {
+		t.Errorf("expected 200 value 0.3333.. got %d", v200)
 		return
 	}
-	v500 := s.CodeDistribution[1].Val
-	if v500 <= 0.66 || v500 >= 0.67 {
-		t.Errorf("expected 200 value 0.6666.. got %f", v500)
+	v500 := distr.Val(0.34)
+	if v500 != 500 {
+		t.Errorf("expected 200 value 0.6666.. got %d", v500)
 		return
 	}
 }

--- a/content/content.go
+++ b/content/content.go
@@ -9,10 +9,11 @@ import (
 
 type NestedContentBuilderFn func(c *config.Content) http.Handler
 
-type ContentHandlerBuilderFn func(c *config.Content, nestedBuilder NestedContentBuilderFn) http.Handler
+type ContentHandlerBuilderFn func(endpointCfg *config.Endpoint,
+	c *config.Content) http.Handler
 
-var (
-	contentBuilders = map[string]ContentHandlerBuilderFn{
+func Build(eCfg *config.Endpoint, cfg *config.Content) http.Handler {
+	contentBuilders := map[string]ContentHandlerBuilderFn{
 		"directory":               DirectoryContentHandler,
 		"file":                    FileContentHandler,
 		"empty":                   EmptyContentHandler,
@@ -21,11 +22,8 @@ var (
 		"status_content_selector": StatusContentSelectorHandler,
 		"proxy":                   ProxyContentHandler,
 	}
-)
-
-func Build(cfg *config.Content) http.Handler {
 	if b, ok := contentBuilders[cfg.Source]; ok {
-		h := b(cfg, Build)
+		h := b(eCfg, cfg)
 		if h != nil {
 			return h
 		}

--- a/content/dummy.go
+++ b/content/dummy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dhontecillas/reqstatsrv/config"
 )
 
-func DummyHandler(cfg *config.Content, nestedBuilder NestedContentBuilderFn) http.Handler {
+func DummyHandler(_ *config.Endpoint, cfg *config.Content) http.Handler {
 	return &DummyPayload{}
 }
 

--- a/content/empty.go
+++ b/content/empty.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dhontecillas/reqstatsrv/config"
 )
 
-func EmptyContentHandler(cfg *config.Content, nestedBuilder NestedContentBuilderFn) http.Handler {
+func EmptyContentHandler(_ *config.Endpoint, cfg *config.Content) http.Handler {
 	return &EmptyPayload{}
 }
 

--- a/content/file.go
+++ b/content/file.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dhontecillas/reqstatsrv/config"
 )
 
-func FileContentHandler(cfg *config.Content, nestedBuilder NestedContentBuilderFn) http.Handler {
+func FileContentHandler(_ *config.Endpoint, cfg *config.Content) http.Handler {
 	return NewFileContent(FileContentConfigFromMap(cfg.Config))
 }
 

--- a/content/proxy.go
+++ b/content/proxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dhontecillas/reqstatsrv/config"
 )
 
-func ProxyContentHandler(cfg *config.Content, nestedBuilder NestedContentBuilderFn) http.Handler {
+func ProxyContentHandler(_ *config.Endpoint, cfg *config.Content) http.Handler {
 	return NewProxyContent(ProxyContentConfigFromMap(cfg.Config))
 }
 

--- a/content/stats.go
+++ b/content/stats.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dhontecillas/reqstatsrv/stats"
 )
 
-func StatsHandler(cfg *config.Content, nestedBuilder NestedContentBuilderFn) http.Handler {
+func StatsHandler(_ *config.Endpoint, cfg *config.Content) http.Handler {
 	return &CounterPayloadHandler{}
 }
 

--- a/content/status_content_selector.go
+++ b/content/status_content_selector.go
@@ -9,8 +9,8 @@ import (
 	"github.com/dhontecillas/reqstatsrv/config"
 )
 
-func StatusContentSelectorHandler(cfg *config.Content, nestedBuilder NestedContentBuilderFn) http.Handler {
-	return NewStatusContentSelector(StatusSelectorConfigFromMap(cfg.Config), nestedBuilder)
+func StatusContentSelectorHandler(eCfg *config.Endpoint, cfg *config.Content) http.Handler {
+	return NewStatusContentSelector(eCfg, StatusSelectorConfigFromMap(cfg.Config))
 }
 
 type StatusRangeContent struct {
@@ -50,16 +50,16 @@ type StatusContentSelector struct {
 	ranges         []contentByStatusRange
 }
 
-func NewStatusContentSelector(cfg *StatusContentSelectorConfig, nestedBuilder NestedContentBuilderFn) *StatusContentSelector {
+func NewStatusContentSelector(eCfg *config.Endpoint, cfg *StatusContentSelectorConfig) *StatusContentSelector {
 	s := &StatusContentSelector{
-		defaultContent: nestedBuilder(&cfg.DefaultContent),
+		defaultContent: Build(eCfg, &cfg.DefaultContent),
 		ranges:         make([]contentByStatusRange, 0, len(cfg.StatusContents)),
 	}
 	for _, rg := range cfg.StatusContents {
 		s.ranges = append(s.ranges, contentByStatusRange{
 			from: rg.From,
 			to:   rg.To,
-			next: nestedBuilder(&rg.Content),
+			next: Build(eCfg, &rg.Content),
 		})
 	}
 	return s

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -10,9 +10,13 @@ import (
 )
 
 func Bind(mux *http.ServeMux, cfg *config.Endpoint) {
-	ch := content.Build(&cfg.Content)
+	ch := content.Build(cfg, &cfg.Content)
 	h := behaviour.Build(ch, cfg.Behaviour)
 
 	s := stats.NewStatsMiddleware(h, cfg.PathPattern, nil, nil)
-	mux.Handle(cfg.PathPattern, s)
+	if cfg.Method == "" {
+		mux.Handle(cfg.PathPattern, s)
+	} else {
+		mux.Handle(cfg.Method+" "+cfg.PathPattern, s)
+	}
 }

--- a/example/config/example.json
+++ b/example/config/example.json
@@ -43,7 +43,7 @@
         },
         {
             "method": "GET",
-            "path_pattern": "/delayed/",
+            "path_pattern": "/delayed/{foo}/bar/",
             "behaviour": [
                 {
                     "name": "delayer",


### PR DESCRIPTION
Even if not used, now we can have params in the endpoint route, and not having problems with serving the files inside a directory content.